### PR TITLE
__init__: fix format of string on ValueError

### DIFF
--- a/fdt/__init__.py
+++ b/fdt/__init__.py
@@ -90,7 +90,7 @@ class FDT(object):
                         item = Node(name)
                         node.append(item)
                     else:
-                        raise ValueError("Path \"{}\" doesn't exists".format(self, path))
+                        raise ValueError("Path \"{}\" doesn't exists".format(path))
                 node = item
 
         return node


### PR DESCRIPTION
The string should contain the incorrect path, not the object's string
representation.