### PR TITLE
Fix serializing strings with embedded quote characters

### DIFF
--- a/fdt/items.py
+++ b/fdt/items.py
@@ -226,7 +226,7 @@ class PropStrings(Property):
         """
         result  = line_offset(tabsize, depth, self.name)
         result += ' = "'
-        result += '", "'.join(self.data)
+        result += '", "'.join([item.replace('"', '\\"') for item in self.data])
         result += '";\n'
         return result
 


### PR DESCRIPTION
Without this change, to_dts can end up writing a DTS with unescaped quote characters in strings, resulting in an invalid DTS that can't be compiled.