### PR TITLE
fix DeprecationWarning for invalid escape sequence

### DIFF
--- a/fdt/misc.py
+++ b/fdt/misc.py
@@ -64,7 +64,7 @@ def get_version_info(text):
 
 
 def strip_comments(text):
-    text = re.sub('//.*?(\r\n?|\n)|/\*.*?\*/', '\n', text, flags=re.S)
+    text = re.sub(r'//.*?(\r\n?|\n)|/\*.*?\*/', '\n', text, flags=re.S)
     return text
 
 


### PR DESCRIPTION
The "\\*" in the regex causes a DeprecationWarning for an invalid escape sequence and will cause a syntax error in py3.12. This changes the string to a raw string to fix.